### PR TITLE
[Week50] Testing all conditions for PilotBeams re-reco

### DIFF
--- a/Validations/Validation_2021_w50_ReReco
+++ b/Validations/Validation_2021_w50_ReReco
@@ -2,7 +2,7 @@
 # Put is None in case you don't have any link
 ValidationRequest       : None
 
-Title                   : Tetsing all conditions for PilotBeams re-reco
+Title                   : Testing all conditions for PilotBeams re-reco
 
 Subsystem               : CMS
 

--- a/Validations/Validation_2021_w50_ReReco
+++ b/Validations/Validation_2021_w50_ReReco
@@ -1,0 +1,61 @@
+# Email/HN link through which this validation is requested.
+# Put is None in case you don't have any link
+ValidationRequest       : None
+
+Title                   : Tetsing all conditions for PilotBeams re-reco
+
+Subsystem               : CMS
+
+# Labels: List of labels separated by comma. Keep it unique for given validation
+#-------------------------------------------------------------------------------
+Labels                  : Week50, 2021, ReReco
+
+# Target GTs here
+#-------------------------------------------------------------------------------
+TargetGT_HLT            : None
+TargetGT_Prompt         : 121X_dataRun3_v13
+TargetGT_Express        : None
+
+# Reference GTs here
+#-------------------------------------------------------------------------------
+ReferenceGT_HLT         : None
+ReferenceGT_Prompt      : 121X_dataRun3_Prompt_v11
+ReferenceGT_Express     : None
+
+# List of Dataset. Comma(,) separated. NO space allowed in between
+#-------------------------------------------------------------------------------
+Dataset                 : /MinimumBias/Commissioning2021-v1/RAW,/ZeroBias/Commissioning2021-v1/RAW
+
+# Put run-number in JSON format. e.g. {'344518': [[1, 1892]]}
+# Multiple run numbers are NOT supported at the moment
+#-------------------------------------------------------------------------------
+Run                     : {'346512': [[1, 500]]}
+
+# Yes/No. Yes, if you want to submit job for computation if local test is successful
+#-------------------------------------------------------------------------------
+Validate                : Yes
+
+# Choices--> HLT, Prompt, Express, HLT/Prompt, HLT/Express, Prompt/Express, HLT/Prompt/Express
+#-------------------------------------------------------------------------------
+WorkflowsToSubmit       : Prompt
+
+#-------------------------------------------------------------------------------
+#-------------------------------------------------------------------------------
+#------- OPTIONAL -------- OPTIONAL -------- OPTIONAL --------- OPTIONAL -------
+
+#-------------------------------------------------------------------------------
+
+# Put CMSSW version of your choice. If None then production version will be used
+HLT_release             : CMSSW_12_1_1
+PR_release              : CMSSW_12_1_1
+Expr_release            : CMSSW_12_1_1
+
+# Put NEW jira ticket number in case jira server is down
+Jira                    : None
+
+# Fill below details in case of run-registry server is down
+b_field                 : None
+class                   : None
+hlt_key                 : None
+
+################################################################################

--- a/condDatasetSubmitter.py
+++ b/condDatasetSubmitter.py
@@ -551,6 +551,7 @@ def createCMSSWConfigs(options,confCondDictionary,allRunsAndBlocks):
             driver_command += "--customise_commands='%s' " % (details['custcommands'])
 
         #Temporary changes
+        driver_command += '--procModifiers siPixelQualityRawToDigi '
         driver_command += '--customise "Configuration/DataProcessing/RecoTLR.customisePostEra_Run3" '
         # ---------
 
@@ -610,6 +611,7 @@ def createCMSSWConfigs(options,confCondDictionary,allRunsAndBlocks):
                 driver_command += "--customise_commands='%s' " % (recodqm['custcommands'])
 
             #Temporary changes
+            driver_command += '--procModifiers siPixelQualityRawToDigi '
             driver_command += '--customise "Configuration/DataProcessing/RecoTLR.customisePostEra_Run3" '
             # ---------
 

--- a/condDatasetSubmitter.py
+++ b/condDatasetSubmitter.py
@@ -552,7 +552,7 @@ def createCMSSWConfigs(options,confCondDictionary,allRunsAndBlocks):
 
         #Temporary changes
         driver_command += '--procModifiers siPixelQualityRawToDigi '
-        driver_command += '--customise "Configuration/DataProcessing/RecoTLR.customisePostEra_Run3" '
+        driver_command += '--customise "Configuration/DataProcessing/RecoTLR.customisePostEra_Run3,RecoLocalCalo/Configuration/customiseHBHEreco.hbheUseM0FullRangePhase1" '
         # ---------
 
         cmssw_command = "cd %s; eval `scramv1 runtime -sh`; cd -" % (options.hltCmsswDir)
@@ -612,7 +612,7 @@ def createCMSSWConfigs(options,confCondDictionary,allRunsAndBlocks):
 
             #Temporary changes
             driver_command += '--procModifiers siPixelQualityRawToDigi '
-            driver_command += '--customise "Configuration/DataProcessing/RecoTLR.customisePostEra_Run3" '
+            driver_command += '--customise "Configuration/DataProcessing/RecoTLR.customisePostEra_Run3,RecoLocalCalo/Configuration/customiseHBHEreco.hbheUseM0FullRangePhase1" '
             # ---------
 
             if options.recoCmsswDir:


### PR DESCRIPTION
Validation to test the full conditions for the ReReco of Pilot Beams 2021 data.
- Only Prompt workflow is configured
- Run: 346512
- CMSSW_12_1_1
- GT: [121X_dataRun3_v13](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/121X_dataRun3_v13)  (ReReco GT)
- Includes changes to `condDatasetSubmitter.py` to 
  - Add the correct procModifier for SiPixelQuality: `--procModifiers siPixelQualityRawToDigi`
  - Add the HCAL time mis-alignment customization: 
    `--customise "RecoLocalCalo/Configuration/customiseHBHEreco.hbheUseM0FullRangePhase1"`
  - These should both be reverted after this validation as they are not (yet?) the default

Few considerations:
 - @pkalbhor please check that everything is ok
 - @pkalbhor in this specific case we only care about the target workflow, so the reference workflow could dropped, but I'm not sure if things would break or not. Any suggestion?
 - @tvami @malbouis note that I didn't apply the HCAL modifier: 
   `--customise RecoLocalCalo/Configuration/customiseHBHEreco.hbheUseM0FullRangePhase1`
   Which will be used in the actual re-reco IIUC. Should we add it? Does it make sense here?
