### PR TITLE
Validation_2022_w4_ECAL_EGM_PF

### DIFF
--- a/Validations/Validation_2022_w4_ECAL_EGM_PF
+++ b/Validations/Validation_2022_w4_ECAL_EGM_PF
@@ -12,9 +12,9 @@ Labels                  : Week4, 2022, ECAL, EGM, PF
 
 # Target GTs here
 #-------------------------------------------------------------------------------
-TargetGT_HLT            : 122X_dataRun3_HLTNew_ECAL_EGM_PF_w4_2022_v1
-TargetGT_Express        : 122X_dataRun3_ExpressNew_ECAL_EGM_PF_w4_2022_v1
-TargetGT_Prompt         : 122X_dataRun3_PromptNew_ECAL_EGM_PF_w4_2022_v1
+TargetGT_HLT            : 122X_dataRun3_HLTNew_ECAL_EGM_PF_w4_2022_v2
+TargetGT_Express        : 122X_dataRun3_ExpressNew_ECAL_EGM_PF_w4_2022_v2
+TargetGT_Prompt         : 122X_dataRun3_PromptNew_ECAL_EGM_PF_w4_2022_v2
 
 # Reference GTs here
 #-------------------------------------------------------------------------------
@@ -42,7 +42,7 @@ WorkflowsToSubmit       : HLT/Prompt/Express
 # Choose the type of condition to submit. 
 # Choices--> New, Reference, Both
 #-------------------------------------------------------------------------------
-NewOrReference          : Both
+NewOrReference          : New
 
 #-------------------------------------------------------------------------------
 #-------------------------------------------------------------------------------

--- a/Validations/Validation_2022_w4_ECAL_EGM_PF
+++ b/Validations/Validation_2022_w4_ECAL_EGM_PF
@@ -1,0 +1,66 @@
+# Email/HN link through which this validation is requested.
+# Put is None in case you don't have any link
+ValidationRequest       : None
+
+Title                   : ECAL+EGM+PF updates in view of Run3 start up
+
+Subsystem               : ECAL, EGM, PF
+
+# Labels: List of labels separated by comma. Keep it unique for given validation
+#-------------------------------------------------------------------------------
+Labels                  : Week4, 2022, ECAL, EGM, PF
+
+# Target GTs here
+#-------------------------------------------------------------------------------
+TargetGT_HLT            : 122X_dataRun3_HLTNew_ECAL_EGM_PF_w4_2022_v1
+TargetGT_Express        : 122X_dataRun3_ExpressNew_ECAL_EGM_PF_w4_2022_v1
+TargetGT_Prompt         : 122X_dataRun3_PromptNew_ECAL_EGM_PF_w4_2022_v1
+
+# Reference GTs here
+#-------------------------------------------------------------------------------
+ReferenceGT_HLT         : 122X_dataRun3_HLT_v2
+ReferenceGT_Express     : 122X_dataRun3_Express_v2
+ReferenceGT_Prompt      : 122X_dataRun3_Prompt_v2
+
+# List of Dataset. Comma(,) separated. NO space allowed in between
+#-------------------------------------------------------------------------------
+Dataset                 : /MinimumBias/Commissioning2021-v1/RAW
+
+# Put run-number in JSON format. e.g. {'344518': [[1, 1892]]}
+# Multiple run numbers are NOT supported at the moment
+#-------------------------------------------------------------------------------
+Run                     : {'346512': [[1, 500]]}
+
+# Yes/No. Yes, if you want to submit job for computation if local test is successful
+#-------------------------------------------------------------------------------
+Validate                : Yes
+
+# Choices--> HLT, Prompt, Express, HLT/Prompt, HLT/Express, Prompt/Express, HLT/Prompt/Express
+#-------------------------------------------------------------------------------
+WorkflowsToSubmit       : HLT/Prompt/Express
+
+# Choose the type of condition to submit. 
+# Choices--> New, Reference, Both
+#-------------------------------------------------------------------------------
+NewOrReference          : Both
+
+#-------------------------------------------------------------------------------
+#-------------------------------------------------------------------------------
+#------- OPTIONAL -------- OPTIONAL -------- OPTIONAL --------- OPTIONAL -------
+
+#-------------------------------------------------------------------------------
+
+# Put CMSSW version of your choice. If None then production version will be used
+HLT_release             : CMSSW_12_2_0
+PR_release              : CMSSW_12_2_0
+Expr_release            : CMSSW_12_2_0
+
+# Put NEW jira ticket number in case jira server is down
+Jira                    : None
+
+# Fill below details in case of run-registry server is down
+b_field                 : None
+class                   : None
+hlt_key                 : None
+
+################################################################################


### PR DESCRIPTION
Validation of ECAl+EGM+PF conditions for the online GTs in preparation of Run3 start up, as requested in:
- ECAL : https://cms-talk.web.cern.ch/t/gt-online-ecal-pfrechit-tags-for-run3/4621
- EGM PF Cluster : https://cms-talk.web.cern.ch/t/hlt-introducing-egm-pf-cluster-correction-tags-for-run3-into-hlt/4820/3
- PF HLT calib : https://cms-talk.web.cern.ch/t/gt-pf-calibration-hlt-tag-for-run-3/3963

The diff of the target wrt reference GTs is:
- HLT: https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/122X_dataRun3_HLT_v2/122X_dataRun3_HLTNew_ECAL_EGM_PF_w4_2022_v2
- Express: https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/122X_dataRun3_Express_v2/122X_dataRun3_ExpressNew_ECAL_EGM_PF_w4_2022_v2
- Prompt: https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/122X_dataRun3_Prompt_v2/122X_dataRun3_PromptNew_ECAL_EGM_PF_w4_2022_v2
