### PR TITLE
Validation_2022_w4_ECAL_EGM_PF (Resubmission)

### DIFF
--- a/Validations/Validation_2022_w4_ECAL_EGM_PF
+++ b/Validations/Validation_2022_w4_ECAL_EGM_PF
@@ -29,7 +29,7 @@ Dataset                 : /MinimumBias/Commissioning2021-v1/RAW
 # Put run-number in JSON format. e.g. {'344518': [[1, 1892]]}
 # Multiple run numbers are NOT supported at the moment
 #-------------------------------------------------------------------------------
-Run                     : {'346512': [[1, 500]]}
+Run                     : {'346512': [[1, 400]]}
 
 # Yes/No. Yes, if you want to submit job for computation if local test is successful
 #-------------------------------------------------------------------------------
@@ -51,9 +51,9 @@ NewOrReference          : New
 #-------------------------------------------------------------------------------
 
 # Put CMSSW version of your choice. If None then production version will be used
-HLT_release             : CMSSW_12_2_0
-PR_release              : CMSSW_12_2_0
-Expr_release            : CMSSW_12_2_0
+HLT_release             : CMSSW_12_2_0_patch1
+PR_release              : CMSSW_12_2_0_patch1
+Expr_release            : CMSSW_12_2_0_patch1
 
 # Put NEW jira ticket number in case jira server is down
 Jira                    : None


### PR DESCRIPTION
Hi All,
This is resubmission due to failures during the previous submission of [1]
CMSSW changed to CMSSW_12_2_0_patch1 from previously used CMSSW_12_2_0 which led to high failure rate.
The issue was raised/fixed here [2]

[1] https://its.cern.ch/jira/browse/CMSALCA-150
[2] cms-sw/cmssw#36779