### PR TITLE
Validation_2022_w6_Tracker (Resubmission with ReReco APE tags)

### DIFF
--- a/Validations/Validation_2022_w6_Tracker
+++ b/Validations/Validation_2022_w6_Tracker
@@ -12,15 +12,15 @@ Labels                  : Week6, 2022, Tracker
 
 # Target GTs here
 #-------------------------------------------------------------------------------
-TargetGT_HLT            : 122X_dataRun3_HLTNew_EOYTkAli_w6_2022_v1
-TargetGT_Express        : 122X_dataRun3_ExpressNew_EOYTkAli_w6_2022_v1
-TargetGT_Prompt         : 122X_dataRun3_PromptNew_EOYTkAli_w6_2022_v1
+TargetGT_HLT            : 122X_dataRun3_HLTNew_EOYTkAli_w6_2022_v2
+TargetGT_Express        : 122X_dataRun3_ExpressNew_EOYTkAli_w6_2022_v2
+TargetGT_Prompt         : 122X_dataRun3_PromptNew_EOYTkAli_w6_2022_v2
 
 # Reference GTs here
 #-------------------------------------------------------------------------------
-ReferenceGT_HLT         : 122X_dataRun3_HLT_v2
-ReferenceGT_Express     : 122X_dataRun3_Express_v2
-ReferenceGT_Prompt      : 122X_dataRun3_Prompt_v2
+ReferenceGT_HLT         : 122X_dataRun3_HLTRef_EOYTkAli_w6_2022_v2
+ReferenceGT_Express     : 122X_dataRun3_ExpressRef_EOYTkAli_w6_2022_v2
+ReferenceGT_Prompt      : 122X_dataRun3_PromptRef_EOYTkAli_w6_2022_v2
 
 # List of Dataset. Comma(,) separated. NO space allowed in between
 #-------------------------------------------------------------------------------


### PR DESCRIPTION
Hi All, 
After clarification from Antonio [1], we are resubmitting validation with the following information.

**HLT New:** 122X_dataRun3_HLTNew_EOYTkAli_w6_2022_v2
**Express New:** 122X_dataRun3_ExpressNew_EOYTkAli_w6_2022_v2
**Prompt New:** 122X_dataRun3_PromptNew_EOYTkAli_w6_2022_v2

**HLT Reference:** 122X_dataRun3_HLTRef_EOYTkAli_w6_2022_v2
**Express Reference:** 122X_dataRun3_ExpressRef_EOYTkAli_w6_2022_v2
**Prompt Reference:** 122X_dataRun3_PromptRef_EOYTkAli_w6_2022_v2

The difference between new and reference GTs are:
**HLT:** https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/122X_dataRun3_HLTNew_EOYTkAli_w6_2022_v2/122X_dataRun3_HLTRef_EOYTkAli_w6_2022_v2
**Express:** https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/122X_dataRun3_ExpressNew_EOYTkAli_w6_2022_v2/122X_dataRun3_ExpressRef_EOYTkAli_w6_2022_v2
**Prompt:** https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/122X_dataRun3_PromptNew_EOYTkAli_w6_2022_v2/122X_dataRun3_PromptRef_EOYTkAli_w6_2022_v2

[1] https://cms-talk.web.cern.ch/t/full-track-validation-eoy-tracker-alignment-conditions-using-cruzet-craft-minbias-data/4537/8
