### PR TITLE
Validation_2022_w8_Tracker (Resubmission)

### DIFF
--- a/Validations/Validation_2022_w8_Tracker
+++ b/Validations/Validation_2022_w8_Tracker
@@ -12,15 +12,15 @@ Labels                  : Week8, 2022, Tracker
 
 # Target GTs here
 #-------------------------------------------------------------------------------
-TargetGT_HLT            : 122X_dataRun3_HLTNew_TkAli_w8_2022_v1
-TargetGT_Express        : 122X_dataRun3_ExpressNew_TkAli_w8_2022_v1
-TargetGT_Prompt         : 122X_dataRun3_PromptNew_TkAli_w8_2022_v1
+TargetGT_HLT            : 122X_dataRun3_HLTNew_TkAli_w8_2022_v2
+TargetGT_Express        : 122X_dataRun3_ExpressNew_TkAli_w8_2022_v2
+TargetGT_Prompt         : 122X_dataRun3_PromptNew_TkAli_w8_2022_v2
 
 # Reference GTs here
 #-------------------------------------------------------------------------------
-ReferenceGT_HLT         : 122X_dataRun3_HLT_v4
-ReferenceGT_Express     : 122X_dataRun3_Express_v3
-ReferenceGT_Prompt      : 122X_dataRun3_Prompt_v3
+ReferenceGT_HLT         : 122X_dataRun3_HLTRef_TkAli_w8_2022_v1
+ReferenceGT_Express     : 122X_dataRun3_ExpressRef_TkAli_w8_2022_v1
+ReferenceGT_Prompt      : 122X_dataRun3_PromptRef_TkAli_w8_2022_v1
 
 # List of Dataset. Comma(,) separated. NO space allowed in between
 #-------------------------------------------------------------------------------


### PR DESCRIPTION
This is a resubmission of the validation requested through [1]
Following are the changes:
Target HLT GT: [122X_dataRun3_HLTNew_TkAli_w8_2022_v2](https://cms-conddb.cern.ch/cmsDbBrowser/search/Prod/122X_dataRun3_HLTNew_TkAli_w8_2022_v2)
Target Express GT: [122X_dataRun3_ExpressNew_TkAli_w8_2022_v2](https://cms-conddb.cern.ch/cmsDbBrowser/search/Prod/122X_dataRun3_ExpressNew_TkAli_w8_2022_v2)
Target Prompt GT:  [122X_dataRun3_PromptNew_TkAli_w8_2022_v2](https://cms-conddb.cern.ch/cmsDbBrowser/search/Prod/122X_dataRun3_PromptNew_TkAli_w8_2022_v2)

Reference HLT GT:  [122X_dataRun3_HLTRef_TkAli_w8_2022_v1](https://cms-conddb.cern.ch/cmsDbBrowser/search/Prod/122X_dataRun3_HLTRef_TkAli_w8_2022_v1)
Reference Express GT:  [122X_dataRun3_ExpressRef_TkAli_w8_2022_v1](https://cms-conddb.cern.ch/cmsDbBrowser/search/Prod/122X_dataRun3_ExpressRef_TkAli_w8_2022_v1)
Reference Prompt GT:  [122X_dataRun3_PromptRef_TkAli_w8_2022_v1](https://cms-conddb.cern.ch/cmsDbBrowser/search/Prod/122X_dataRun3_PromptRef_TkAli_w8_2022_v1)

Differences are: 
HLT: [Link](https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/122X_dataRun3_HLTNew_TkAli_w8_2022_v2/122X_dataRun3_HLTRef_TkAli_w8_2022_v1)
Express: [Link](https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/122X_dataRun3_ExpressNew_TkAli_w8_2022_v2/122X_dataRun3_ExpressRef_TkAli_w8_2022_v1)
Prompt: [Link](https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/122X_dataRun3_PromptNew_TkAli_w8_2022_v2/122X_dataRun3_PromptRef_TkAli_w8_2022_v1)

All other configuration is same as previous submission submitted through this [2]
[1] https://cms-talk.web.cern.ch/t/full-track-validation-tracker-alignment-conditions-for-craft-2022/7276/2
[2] https://cms-talk.web.cern.ch/t/hlt-prompt-express-full-track-validation-of-tracker-alignment-conditions-update-for-craft22-week-8-2022/7294